### PR TITLE
Fix USA keyword detection

### DIFF
--- a/server.py
+++ b/server.py
@@ -39,7 +39,12 @@ TRANSLATORS = {
 COUNTRY_KEYWORDS = {
     "uzbekistan": ["Republic of Uzbekistan", "O'zbekiston Respublikasi"],
     "india": ["Republic of India", "भारत गणराज्य"],
-    "usa": ["Republic of USA", "USA", "The United States of America", "America"],
+    "usa": [
+        "United States of America",
+        "USA",
+        "The United States of America",
+        "America",
+    ],
     "kazakhstan": ["KAZ", "Republic of Kazakhstan", "ҚАЗАҚСТАН"],
     "china": ["REPUBLIC OF CHINA", "CHN", "China"],
 }


### PR DESCRIPTION
## Summary
- refine the country keywords for USA detection

## Testing
- `python -m py_compile server.py`
- `python -m py_compile translators/translator_ind.py`
- `python -m py_compile translators/translator_usa.py translators/translator_kz.py translators/translator_uzb.py translators/translator_china.py`
- `python server.py` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_684292d38168832c904078fb5149a567